### PR TITLE
Re-write migration with cursor-side fetching

### DIFF
--- a/ocdapi/migrations/0002_auto_20180326_1429.py
+++ b/ocdapi/migrations/0002_auto_20180326_1429.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
             """)
 
             while True:
-                cursor.execute("FETCH 2 FROM bills_cursor")
+                cursor.execute("FETCH 1000 FROM bills_cursor")
                 bill_chunk = cursor.fetchall()
 
                 if not bill_chunk:


### PR DESCRIPTION
This PR reduces the memory consumption by iterating over the mangled bills in small batches.